### PR TITLE
update proportion calculation

### DIFF
--- a/02_munge/src/munge_usgs.py
+++ b/02_munge/src/munge_usgs.py
@@ -22,7 +22,9 @@ def process_to_timestep(df, cols, agg_level, prop_obs_required):
     # aggregate data to specified timestep
     if agg_level == 'daily':
         # get proportion of measurements available for timestep
-        prop_df = df.groupby([df['datetime'].dt.date]).count()[cols].div(df.groupby([df['datetime'].dt.date]).count()['datetime'], axis=0)
+        expected_measurements = df.groupby([df['datetime'].dt.date]).count().mode()[cols].loc[0]
+        observed_measurements = df.groupby([df['datetime'].dt.date]).count()[cols].loc[:]
+        prop_df = observed_measurements / expected_measurements
         # calculate averages for timestep
         df = df.groupby([df['datetime'].dt.date]).mean()
     # only keep averages where we have enough measurements


### PR DESCRIPTION
I updated the calculation of the proportion of measurements per day. Previously, I was counting the number of timestamps per day as our expected number of observations. As described in issue #27, it was dropping certain parameters because they were measured less frequently than other parameters at that site. To fix the issue, I counted the measurements taken per day for each parameter individually. I then took the mode of each of those counts to be the expected number of measurements for that parameter. I think used this as the denominator when calculation what proportion of measurements we have available. 