### PR TITLE
update IT figure naming

### DIFF
--- a/03_it_analysis/src/it_analysis_data_prep.py
+++ b/03_it_analysis/src/it_analysis_data_prep.py
@@ -288,7 +288,8 @@ def apply_preprocessing_functions(var_list, var_list_historical, source_sink, ou
                 ax1.set_ylabel(ucn)
                 ax2.hist(var_list[site_num][ucn])
                 ax2.set_ylabel('Count')
-                ax1.set_title(ucn+'_Raw')
+                plt.suptitle(ucn)
+                ax1.set_title('raw')
                 fig.savefig(out_dir+'preprocess_plots/' +ucn + '_raw.png', bbox_inches = 'tight')
                 #plt.show()
                 plt.close()
@@ -322,7 +323,12 @@ def apply_preprocessing_functions(var_list, var_list_historical, source_sink, ou
                         ax1.set_ylabel(ucn)
                         ax2.hist(temp_data)
                         ax2.set_ylabel('Count')
-                        ax1.set_title(ucn + '_' + value + '_step ' + str(count+1)+ '/'+ str(len(pre_process_steps[pp_key])))
+                        plt.suptitle(ucn)
+                        if count==0:
+                            pltsubt = value
+                        else:                            
+                            pltsubt = pltsubt+', '+ value
+                        ax1.set_title(pltsubt)
                         fname = fname+'_'+ value
                         fig.savefig(fname+'.png', bbox_inches = 'tight')
                         #plt.show()

--- a/03_it_analysis/src/it_analysis_data_prep.py
+++ b/03_it_analysis/src/it_analysis_data_prep.py
@@ -283,18 +283,17 @@ def apply_preprocessing_functions(var_list, var_list_historical, source_sink, ou
                 ucn = [string for string in cols if pp_key in string][0]
                 
                 #if the preprocess step is set to 'none' create a histogram of the raw data
-                if pre_process_steps[pp_key][0] == 'none':
-                    #create histogram of raw data
-                    fig, (ax1, ax2) = plt.subplots(2)
-                    ax1.plot(var_list[site_num].index, var_list[site_num][ucn])
-                    ax1.set_ylabel(ucn)
-                    ax2.hist(var_list[site_num][ucn])
-                    ax2.set_ylabel('Count')
-                    ax1.set_title(ucn+'_Raw')
-                    fig.savefig(out_dir+'preprocess_plots/' +ucn + '_Raw.png', bbox_inches = 'tight')
-                    #plt.show()
-                    plt.close()
-                    
+                fig, (ax1, ax2) = plt.subplots(2)
+                ax1.plot(var_list[site_num].index, var_list[site_num][ucn])
+                ax1.set_ylabel(ucn)
+                ax2.hist(var_list[site_num][ucn])
+                ax2.set_ylabel('Count')
+                ax1.set_title(ucn+'_Raw')
+                fig.savefig(out_dir+'preprocess_plots/' +ucn + '_raw.png', bbox_inches = 'tight')
+                #plt.show()
+                plt.close()
+
+                if pre_process_steps[pp_key][0] == 'none':                    
                     #store the variable's data
                     raw_data = var_list[site_num][ucn].copy()
                     var_proc_df[ucn] = raw_data
@@ -305,18 +304,8 @@ def apply_preprocessing_functions(var_list, var_list_historical, source_sink, ou
                     temp_data = var_list[site_num][ucn].copy()
                     temp_data_historical = var_list_historical[site_num][ucn].copy()
                     
-                    #create histogram of raw data
-                    fig, (ax1, ax2) = plt.subplots(2)
-                    ax1.plot(var_list[site_num].index, temp_data)
-                    ax1.set_ylabel(ucn)
-                    ax2.hist(temp_data)
-                    ax2.set_ylabel('Count')
-                    ax1.set_title(ucn + ' Raw')
-                    fig.savefig(out_dir+'preprocess_plots/' +ucn + '_0_Raw.png', bbox_inches = 'tight')
-                    #plt.show()
-                    plt.close()
-                    
                     #for each preprocessing step for that variable
+                    fname = os.path.join(out_dir, 'preprocess_plots', ucn)
                     for count,value in enumerate(pre_process_steps[pp_key]):
                         #apply the function
                         func = getattr(ppf,value)
@@ -334,7 +323,8 @@ def apply_preprocessing_functions(var_list, var_list_historical, source_sink, ou
                         ax2.hist(temp_data)
                         ax2.set_ylabel('Count')
                         ax1.set_title(ucn + '_' + value + '_step ' + str(count+1)+ '/'+ str(len(pre_process_steps[pp_key])))
-                        fig.savefig(out_dir+'preprocess_plots/' +ucn + '_'+str(count+1)+' '+ value+'.png', bbox_inches = 'tight')
+                        fname = fname+'_'+ value
+                        fig.savefig(fname+'.png', bbox_inches = 'tight')
                         #plt.show()
                         plt.close()
                         

--- a/Snakefile
+++ b/Snakefile
@@ -6,6 +6,7 @@ rule all:
     input:
         "03_it_analysis/out/srcs_proc_lagged",
         "03_it_analysis/out/snks_proc"
+
 rule fetch_usgs_nwis:
     input:
         "01_fetch/fetch_config.yaml"

--- a/Snakefile
+++ b/Snakefile
@@ -1,28 +1,24 @@
 configfile: "01_fetch/fetch_config.yaml"
 configfile: "02_munge/munge_config.yaml"
 configfile: "03_it_analysis/it_analysis_data_prep_config.yaml"
-configfile: "03_it_analysis/it_analysis_preprocess_config.yaml"
 
 rule all:
     input:
-         "logfile.log"
-
+        "03_it_analysis/out/srcs_proc_lagged",
+        "03_it_analysis/out/snks_proc"
 rule fetch_usgs_nwis:
     input:
         "01_fetch/fetch_config.yaml"
     output:
         expand("01_fetch/out/usgs_nwis_{site}.txt", site=config["fetch_usgs.py"]["site_ids"]),
-        "01_fetch/out/usgs_nwis_params.txt"
     shell:
         "python -m 01_fetch.src.fetch_usgs"
 
 rule munge_usgs_nwis:
     input:
         expand("01_fetch/out/usgs_nwis_{site}.txt", site=config["fetch_usgs.py"]["site_ids"]),
-        "01_fetch/out/usgs_nwis_params.txt"
     output:
         expand("02_munge/out/usgs_nwis_{site}.csv", site=config["fetch_usgs.py"]["site_ids"]),
-        "02_munge/out/usgs_nwis_params.csv"
     shell:
         "python -m 02_munge.src.munge_usgs"
 
@@ -30,9 +26,8 @@ rule it_analysis_data_prep:
     input:
         expand("02_munge/out/usgs_nwis_{site}.csv", site=config["fetch_usgs.py"]["site_ids"]),
     output:
-        "03_it_analysis/it_analysis_preprocess_config.yaml",
-        "03_it_analysis/out/srcs_proc",
-        "03_it_analysis/out/snks"
+        "03_it_analysis/out/srcs_proc_lagged",
+        "03_it_analysis/out/snks_proc"
     shell:
         "python -m 03_it_analysis.src.it_analysis_data_prep"
 


### PR DESCRIPTION
Updated figure naming to just include order of steps, but not numbering. If we remove seasonal signal then normalize, it doesn't matter if those are steps 1 and 2 out of 2 steps or out of 3,4, etc. If we start testing a bunch of different iterations of preprocessing, then numbering could get confusing. These are the format of the new plot titles I'm suggesting:
![image](https://user-images.githubusercontent.com/30877272/153926512-36c1640e-ab71-43fc-b56b-205ed41eb072.png)
