### PR TITLE
add function to extract daily tidal data

### DIFF
--- a/01_fetch/fetch_config.yaml
+++ b/01_fetch/fetch_config.yaml
@@ -37,14 +37,14 @@ fetch_noaa_nos.py:
   - '8536110' # Cape May
   - '8557380' # Lewes
   - '8548989' # Newbold, PA
-  - '8539094' # Burlington, NJ
-  - '8546252' # Bridesburg, NJ
-  - '8545240' # Philadelphia, PA
-  - '8540433' # Marcus Hook, PA
-  - '8551762' # Delaware City, DE
-  - '8551910' # Reedy Point, DE
-  - '8537121' # Ship John Shoal, NJ
-  - '8555889' # Brandywine Shoal Lighthouse, DE
+  #- '8539094' # Burlington, NJ
+  #- '8546252' # Bridesburg, NJ
+  #- '8545240' # Philadelphia, PA
+  #- '8540433' # Marcus Hook, PA
+  #- '8551762' # Delaware City, DE
+  #- '8551910' # Reedy Point, DE
+  #- '8537121' # Ship John Shoal, NJ
+  #- '8555889' # Brandywine Shoal Lighthouse, DE
 
   # options:
   # HAT: Highest Astronomical Tide
@@ -88,5 +88,5 @@ fetch_noaa_nos.py:
   # options: csv, json, xml
   file_format: 'json'
 
-  start_year: '2019'
+  start_year: '2000'
   end_year: '2019'

--- a/Snakefile
+++ b/Snakefile
@@ -22,6 +22,17 @@ rule munge_usgs_nwis:
         expand("02_munge/out/usgs_nwis_{site}.csv", site=config["fetch_usgs.py"]["site_ids"]),
     shell:
         "python -m 02_munge.src.munge_usgs"
+        
+rule munge_noaa_nos:
+    input:
+        expand("01_fetch/out/noaa_nos_{site}_conductivity.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+        expand("01_fetch/out/noaa_nos_{site}_predictions.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+        expand("01_fetch/out/noaa_nos_{site}_water_level.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+    output:
+        expand("02_munge/out/noaa_nos_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+        expand("02_munge/out/noaa_nos_daily_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"])
+    shell:
+        "python -m 02_munge.src.munge_noaa_nos"
 
 rule it_analysis_data_prep:
     input:


### PR DESCRIPTION
I added a function to extract daily signal from the subdaily tidal data. The function is contained within `munge_noaa.py` and it is called `extract_daily_tidal_data`. Right now we are extracting 5 different daily metrics:

- water level maximum - minimum
- water level maximum
- water level observed - predicted
- water level filtered using a butterworth filter to extract longer period signals
- mean conductivity

The output files are written as `02_munge/out/noaa_nos_daily_{site}.csv` and the subdaily noaa nos data are now written to a subdirectory within the `02_munge/out` folder called `subdaily`