### PR TITLE
add atmospheric pressure to noaa fetch and munge steps

### DIFF
--- a/01_fetch/fetch_config.yaml
+++ b/01_fetch/fetch_config.yaml
@@ -39,12 +39,12 @@ fetch_noaa_nos.py:
   #- '8548989' # Newbold, PA
   #- '8539094' # Burlington, NJ
   #- '8546252' # Bridesburg, NJ
-  #- '8545240' # Philadelphia, PA
+  - '8545240' # Philadelphia, PA
   #- '8540433' # Marcus Hook, PA
   #- '8551762' # Delaware City, DE
   - '8551910' # Reedy Point, DE
   #- '8537121' # Ship John Shoal, NJ
-  #- '8555889' # Brandywine Shoal Lighthouse, DE
+  - '8555889' # Brandywine Shoal Lighthouse, DE
 
   # options:
   # HAT: Highest Astronomical Tide

--- a/01_fetch/fetch_config.yaml
+++ b/01_fetch/fetch_config.yaml
@@ -42,7 +42,7 @@ fetch_noaa_nos.py:
   #- '8545240' # Philadelphia, PA
   #- '8540433' # Marcus Hook, PA
   #- '8551762' # Delaware City, DE
-  #- '8551910' # Reedy Point, DE
+  - '8551910' # Reedy Point, DE
   #- '8537121' # Ship John Shoal, NJ
   #- '8555889' # Brandywine Shoal Lighthouse, DE
 
@@ -75,6 +75,8 @@ fetch_noaa_nos.py:
       - 'water_level'
       - 'conductivity'
       - 'predictions'
+      - 'air_pressure'
+      #- 'air_temperature'
 
   # options:
   # gmt: Greenwich Mean Time

--- a/02_munge/munge_config.yaml
+++ b/02_munge/munge_config.yaml
@@ -63,7 +63,16 @@ munge_noaa_nos.py:
     # (N) A flag that when set to 1 indicates that the minimum expected conductivity was exceeded
     # (R) A flag that when set to 1 indicates that the rate of change tolerance limit was exceeded
     'conductivity': [True, True, True]
-  
+    # Air pressure Data Flags - in order of listing:
+    # (X) A flag that when set to 1 indicates that the maximum expected conductivity was exceeded
+    # (N) A flag that when set to 1 indicates that the minimum expected conductivity was exceeded
+    # (R) A flag that when set to 1 indicates that the rate of change tolerance limit was exceeded
+    'air_pressure': [True, True, True]
+    # Air temperature Data Flags - in order of listing:
+    # (X) A flag that when set to 1 indicates that the maximum expected conductivity was exceeded
+    # (N) A flag that when set to 1 indicates that the minimum expected conductivity was exceeded
+    # (R) A flag that when set to 1 indicates that the rate of change tolerance limit was exceeded
+    #'air_temperature': [True, True, True]
   # determine what QA/QC levels to drop
   qa_to_drop:
     - 'p' # preliminary

--- a/02_munge/src/munge_noaa_nos.py
+++ b/02_munge/src/munge_noaa_nos.py
@@ -158,11 +158,15 @@ def extract_daily_tidal_data(hourly_tidal_data, site, read_location, write_locat
     'wl_max' : hourly_tidal_data.groupby(hourly_tidal_data.datetime)['water_level'].max(),
     'wl_obs_pred':hourly_tidal_data.groupby(hourly_tidal_data.datetime)['obs_pred'].sum(),
     'wl_filtered':hourly_tidal_data.groupby(hourly_tidal_data.datetime)['water_level_filtered'].mean(),
-    'conductivity': hourly_tidal_data.groupby(hourly_tidal_data.datetime)['conductivity'].mean()
+    'air_pressure': hourly_tidal_data.groupby(hourly_tidal_data.datetime)['air_pressure'].mean()
+    #'air_temperature': hourly_tidal_data.groupby(hourly_tidal_data.datetime)['air_temperature'].mean()
     }
 
-    daily_df = pd.DataFrame(data = d, index = d['conductivity'].index)
-    daily_df
+    daily_df = pd.DataFrame(data = d, index = d['wl_range'].index)
+    
+    if 'conductivity' in hourly_tidal_data.columns:
+        d['conductivity'] = hourly_tidal_data.groupby(hourly_tidal_data.datetime)['conductivity'].mean()
+    
     
     # save pre-processed data
     print("processed site "+ site +" to daily time step")

--- a/03_it_analysis/it_analysis_data_prep_config.yaml
+++ b/03_it_analysis/it_analysis_data_prep_config.yaml
@@ -12,6 +12,7 @@ it_analysis_data_prep.py:
         - 'wl_obs_pred'
         - 'wl_filtered'
         - 'conductivity'
+        - 'air_pressure'
     #the sinks to be analyzed, this will likely be the salt front location
     snks:
         - 'saltfront_daily'
@@ -52,6 +53,12 @@ it_analysis_data_prep.py:
                 conductivity:
                     - remove_seasonal_signal
                     - normalize
+                air_pressure:
+                    - remove_seasonal_signal
+                    - normalize
+                #air_temperature:
+                #   - remove_seasonal_signal
+                #   - normalize
             sinks:
                 saltfront:
                     - remove_seasonal_signal
@@ -84,7 +91,10 @@ it_analysis_data_prep.py:
                     - none
                 conductivity:
                     - none
-
+                air_pressure:
+                    - none
+                #air_temperature:
+                #    - none
             sinks:
                 saltfront:
                     - none

--- a/Snakefile
+++ b/Snakefile
@@ -6,39 +6,46 @@ rule all:
     input:
         "03_it_analysis/out/srcs_proc_lagged",
         "03_it_analysis/out/snks_proc",
-        expand("02_munge/out/subdaily/noaa_nos_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"])
+        expand("02_munge/out/subdaily/noaa_nossubdaily_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"])
 
 rule fetch_usgs_nwis:
     input:
         "01_fetch/fetch_config.yaml"
     output:
-        expand("01_fetch/out/usgs_nwis_{site}.txt", site=config["fetch_usgs.py"]["site_ids"]),
+        expand("01_fetch/out/usgs_nwis_{usgs_site}.txt", usgs_site=config["fetch_usgs.py"]["site_ids"]),
     shell:
         "python -m 01_fetch.src.fetch_usgs"
+        
+rule fetch_noaa_nos:
+    input:
+        "01_fetch/fetch_config.yaml"
+    output:
+        expand("01_fetch/out/noaa_noss_{noaa_site}_{noaa_product}.txt", noaa_site=config["fetch_noaa_nos.py"]["station_ids"], noaa_product = config["fetch_noaa_nos.py"]["products"]),
+    shell:
+        "python -m 01_fetch.src.fetch_noaa_nos"
+
 
 rule munge_usgs_nwis:
     input:
-        expand("01_fetch/out/usgs_nwis_{site}.txt", site=config["fetch_usgs.py"]["site_ids"]),
+        expand("01_fetch/out/usgs_nwis_{usgs_site}.txt", usgs_site=config["fetch_usgs.py"]["site_ids"]),
     output:
-        expand("02_munge/out/usgs_nwis_{site}.csv", site=config["fetch_usgs.py"]["site_ids"]),
+        expand("02_munge/out/usgs_nwis_{usgs_site}.csv", usgs_site=config["fetch_usgs.py"]["site_ids"]),
     shell:
         "python -m 02_munge.src.munge_usgs"
         
 rule munge_noaa_nos:
     input:
-        expand("01_fetch/out/noaa_nos_{site}_conductivity.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
-        expand("01_fetch/out/noaa_nos_{site}_predictions.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
-        expand("01_fetch/out/noaa_nos_{site}_water_level.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+        expand("01_fetch/out/noaa_noss_{noaa_site}_{noaa_product}.txt", noaa_site=config["fetch_noaa_nos.py"]["station_ids"], noaa_product = config["fetch_noaa_nos.py"]["products"])
     output:
-        expand("02_munge/out/subdaily/noaa_nos_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
-        expand("02_munge/out/noaa_nos_daily_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"])
+        expand("02_munge/out/subdaily/noaa_nossubdaily_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+        expand("02_munge/out/noaa_nos_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"])
     shell:
         "python -m 02_munge.src.munge_noaa_nos"
 
 rule it_analysis_data_prep:
     input:
-        expand("02_munge/out/usgs_nwis_{site}.csv", site=config["fetch_usgs.py"]["site_ids"]),
-        expand("02_munge/out/noaa_nos_daily_{site}.csv", site=config["fetch_noaa_nos.py"]["station_ids"]),
+        expand("02_munge/out/usgs_nwis_{usgs_site}.csv", usgs_site=config["fetch_usgs.py"]["site_ids"]),
+        expand("02_munge/out/noaa_nos_daily_{noaa_site}.csv", noaa_site=config["fetch_noaa_nos.py"]["station_ids"]),
     output:
         "03_it_analysis/out/srcs_proc_lagged",
         "03_it_analysis/out/snks_proc"


### PR DESCRIPTION
This addresses #68 , atmospheric pressure is fetched from noaa and munged to a daily time step. I used [this site](https://opendap.co-ops.nos.noaa.gov/erddap/tabledap/index.html?page=1&itemsPerPage=1000) to look up the flag codes for air pressure and I think they are the same as for conductivity, but we should double check to make sure. I also added the functionality to fetch and munge air temperature from the noaa stations, but I have not implemented it yet.