### PR TITLE
fill gaps in discharge at Schuylkill and Trenton with PRMS predictions

### DIFF
--- a/02_munge/munge_config.yaml
+++ b/02_munge/munge_config.yaml
@@ -89,3 +89,19 @@ munge_noaa_nos.py:
     fs: 10
     # desired product to filter
     product: 'water_level'
+
+fill_discharge_prms.py
+    #location of data release
+    sb_url: 'https://www.sciencebase.gov/catalog/file/get/5f6a289982ce38aaa2449135?f=__disk__a6%2Fb3%2Ffb%2Fa6b3fb14393cb6b83d25897b395a92c4f4a193ed'
+    #data file
+    prms_predictions: 'sntemp_inputs_outputs_drb'
+    #destination to write 
+    destination: '99_scratch/drb_estuary_salinity_scratch/data/'
+    #segment ids for trenton and schuylkill
+    trenton_seg_id_nat: 1498
+    schuylkill_seg_id_nat: 2338
+    #location of the files in munge, they will be overwritten with gap filled data
+    nwis_trenton_location: '02_munge/out/usgs_nwis_01463500.csv'
+    nwis_schuylkill_location: '02_munge/out/usgs_nwis_01474500.csv'
+    
+

--- a/02_munge/munge_config.yaml
+++ b/02_munge/munge_config.yaml
@@ -90,18 +90,19 @@ munge_noaa_nos.py:
     # desired product to filter
     product: 'water_level'
 
-fill_discharge_prms.py
+fill_discharge_prms.py:
     #location of data release
     sb_url: 'https://www.sciencebase.gov/catalog/file/get/5f6a289982ce38aaa2449135?f=__disk__a6%2Fb3%2Ffb%2Fa6b3fb14393cb6b83d25897b395a92c4f4a193ed'
     #data file
     prms_predictions: 'sntemp_inputs_outputs_drb'
     #destination to write 
-    destination: '99_scratch/drb_estuary_salinity_scratch/data/'
-    #segment ids for trenton and schuylkill
-    trenton_seg_id_nat: 1498
-    schuylkill_seg_id_nat: 2338
-    #location of the files in munge, they will be overwritten with gap filled data
-    nwis_trenton_location: '02_munge/out/usgs_nwis_01463500.csv'
-    nwis_schuylkill_location: '02_munge/out/usgs_nwis_01474500.csv'
+    destination: '02_munge/in/'
+    fill_segments:
+      trenton:
+        nwis_site: 01463500
+        seg_id_nat: 1498
+      schuylkill:
+        nwis_site: 01474500
+        seg_id_nat: 2338
     
 

--- a/02_munge/src/fill_discharge_prms.py
+++ b/02_munge/src/fill_discharge_prms.py
@@ -28,37 +28,29 @@ def download_unzip_sb(sb_url, prms_predictions, destination):
         
 
 
-def fill_discharge_prms(trenton_seg_id_nat, schuylkill_seg_id_nat, nwis_trenton_location, nwis_schuylkill_location, destination, prms_predictions):
+def fill_discharge_prms(fill_segments, destination, prms_predictions):
     '''reads in prms predictions of discharge and fills nan gaps for trenton and schuylkill nwis time series
-    :trenton_seg_id_nat: [int] segment id closest to trenton discharge location
-    :schuylkill_seg_id_nat: [int] segment id closest to schylkill discharge location
-    :nwis_trenton_location: [str] location of munged trenton nwis .csv
-    :nwis_schuylkill_location: [str] location of munged schuylkill nwis .csv
+    :fill_segments: [dict] dictionary of sites to fill data for; each site in the dictionary contains 'nwis_site' (nwis site number) and 'seg_id_nat' (segment id closest to discharge location)
     :destination: [str] directory where prms data file is located
     :prms_predictions: [str] name of prms file'''
     
     sn_temp_data = pd.read_csv(os.path.join(destination,prms_predictions+'.csv'), parse_dates = True, index_col = 'date')
     
-    sn_temp_trenton = sn_temp_data[sn_temp_data['seg_id_nat'] == trenton_seg_id_nat]
-    sn_temp_schuylkill = sn_temp_data[sn_temp_data['seg_id_nat'] == schuylkill_seg_id_nat]
-    
-    nwis_trenton = pd.read_csv(nwis_trenton_location, parse_dates = True, index_col = 'datetime')
-    nwis_schuylkill = pd.read_csv(nwis_schuylkill_location, parse_dates = True, index_col = 'datetime')
-    
+for segment_details in fill_segments.values():
+    sn_temp_site = sn_temp_data[sn_temp_data['seg_id_nat'] == segment_details['seg_id_nat']]
+
+    nwis_data_path = os.path.join('02_munge', 'out', 'D', 'usgs_nwis_{}.csv'.format(segment_details['nwis_site']))
+    nwis_site_data = pd.read_csv(nwis_data_path, parse_dates = True, index_col = 'datetime')
+
     #fill the gaps make sure to from cubic meters to cfs
-    nwis_trenton['filled'] = nwis_trenton['discharge'].fillna(sn_temp_trenton['seg_outflow']*35.315)
-    nwis_schuylkill['filled'] = nwis_schuylkill['discharge'].fillna(sn_temp_schuylkill['seg_outflow']*35.315)
-    
+    nwis_site_data['filled'] = nwis_site_data['discharge'].fillna(sn_temp_site['seg_outflow']*35.315)
+
     #drop the old discharge and rename filled as discharge
-    nwis_trenton = nwis_trenton.drop(columns = 'discharge')
-    nwis_trenton['discharge'] = nwis_trenton['filled'].rename('discharge')
-    
-    nwis_schuylkill = nwis_schuylkill.drop(columns = 'discharge')
-    nwis_schuylkill['discharge'] = nwis_schuylkill['filled'].rename('discharge')
-    
+    nwis_site_data = nwis_site_data.drop(columns = 'discharge')
+    nwis_site_data.rename(columns = {'filled':'discharge'}, inplace=True)
+
     #write to dataframe
-    nwis_trenton.to_csv(nwis_trenton_location)
-    nwis_schuylkill.to_csv(nwis_schuylkill_location)
+    nwis_site_data.to_csv(nwis_data_path)
 
 
 def main():
@@ -69,13 +61,10 @@ def main():
     sb_url = config['sb_url']
     prms_predictions = config['prms_predictions']
     destination = config['destination']
-    trenton_seg_id_nat = config['trenton_seg_id_nat']
-    schuylkill_seg_id_nat = config['schuylkill_seg_id_nat']
-    nwis_trenton_location = config['nwis_trenton_location']
-    nwis_schuylkill_location = config['nwis_schuylkill_location']
+    fill_segments = config['fill_segments']
     
     download_unzip_sb(sb_url, prms_predictions, destination)
-    fill_discharge_prms(trenton_seg_id_nat, schuylkill_seg_id_nat, nwis_trenton_location, nwis_schuylkill_location, destination, prms_predictions)
+    fill_discharge_prms(fill_segments, destination, prms_predictions)
 
 if __name__ == '__main__':
     main()

--- a/02_munge/src/fill_discharge_prms.py
+++ b/02_munge/src/fill_discharge_prms.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Mar 22 08:01:27 2022
+
+@author: ggorski
+"""
+
+import os
+import pandas as pd
+import sciencebasepy
+import yaml
+import zipfile
+
+
+
+
+def download_unzip_sb(sb_url, prms_predictions, destination):
+    '''downloads prms predictions of discharge from science base data release: https://www.sciencebase.gov/catalog/item/5f6a289982ce38aaa2449135
+    :sb_url: [str] url for downloading zip file
+    :prms_predictions: [str] specific file name 
+    :destination: [str] where the file will be downloaded to'''
+    
+    os.makedirs(destination, exist_ok=True)
+    sb = sciencebasepy.SbSession()
+    sb.download_file(sb_url, prms_predictions+'.zip', destination)
+    with zipfile.ZipFile(os.path.join(destination,prms_predictions+'.zip'), 'r') as zip_ref:
+        zip_ref.extractall(destination)
+        
+
+
+def fill_discharge_prms(trenton_seg_id_nat, schuylkill_seg_id_nat, nwis_trenton_location, nwis_schuylkill_location, destination, prms_predictions):
+    '''reads in prms predictions of discharge and fills nan gaps for trenton and schuylkill nwis time series
+    :trenton_seg_id_nat: [int] segment id closest to trenton discharge location
+    :schuylkill_seg_id_nat: [int] segment id closest to schylkill discharge location
+    :nwis_trenton_location: [str] location of munged trenton nwis .csv
+    :nwis_schuylkill_location: [str] location of munged schuylkill nwis .csv
+    :destination: [str] directory where prms data file is located
+    :prms_predictions: [str] name of prms file'''
+    
+    sn_temp_data = pd.read_csv(os.path.join(destination,prms_predictions+'.csv'), parse_dates = True, index_col = 'date')
+    
+    sn_temp_trenton = sn_temp_data[sn_temp_data['seg_id_nat'] == trenton_seg_id_nat]
+    sn_temp_schuylkill = sn_temp_data[sn_temp_data['seg_id_nat'] == schuylkill_seg_id_nat]
+    
+    nwis_trenton = pd.read_csv(nwis_trenton_location, parse_dates = True, index_col = 'datetime')
+    nwis_schuylkill = pd.read_csv(nwis_schuylkill_location, parse_dates = True, index_col = 'datetime')
+    
+    #fill the gaps make sure to from cubic meters to cfs
+    nwis_trenton['filled'] = nwis_trenton['discharge'].fillna(sn_temp_trenton['seg_outflow']*35.315)
+    nwis_schuylkill['filled'] = nwis_schuylkill['discharge'].fillna(sn_temp_schuylkill['seg_outflow']*35.315)
+    
+    #drop the old discharge and rename filled as discharge
+    nwis_trenton = nwis_trenton.drop(columns = 'discharge')
+    nwis_trenton['discharge'] = nwis_trenton['filled'].rename('discharge')
+    
+    nwis_schuylkill = nwis_schuylkill.drop(columns = 'discharge')
+    nwis_schuylkill['discharge'] = nwis_schuylkill['filled'].rename('discharge')
+    
+    #write to dataframe
+    nwis_trenton.to_csv(nwis_trenton_location)
+    nwis_schuylkill.to_csv(nwis_schuylkill_location)
+
+
+def main():
+    # import config
+    with open("02_munge/munge_config.yaml", 'r') as stream:
+        config = yaml.safe_load(stream)['fill_discharge_prms.py']
+    
+    sb_url = config['sb_url']
+    prms_predictions = config['prms_predictions']
+    destination = config['destination']
+    trenton_seg_id_nat = config['trenton_seg_id_nat']
+    schuylkill_seg_id_nat = config['schuylkill_seg_id_nat']
+    nwis_trenton_location = config['nwis_trenton_location']
+    nwis_schuylkill_location = config['nwis_schuylkill_location']
+    
+    download_unzip_sb(sb_url, prms_predictions, destination)
+    fill_discharge_prms(trenton_seg_id_nat, schuylkill_seg_id_nat, nwis_trenton_location, nwis_schuylkill_location, destination, prms_predictions)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I added two functions in the PR:

`download_unzip_sb`: downloads prms predictions of discharge from science base data release: https://www.sciencebase.gov/catalog/item/5f6a289982ce38aaa2449135
inputs:
    sb_url: [str] url for downloading zip file
    prms_predictions: [str] specific file name 
    destination: [str] where the file will be downloaded to
outputs:
    none

`fill_discharge_prms`:reads in prms predictions of discharge and fills nan gaps for trenton and schuylkill nwis time series
inputs:
    trenton_seg_id_nat: [int] segment id closest to trenton discharge location
    schuylkill_seg_id_nat: [int] segment id closest to schylkill discharge location
    nwis_trenton_location: [str] location of munged trenton nwis .csv
    nwis_schuylkill_location: [str] location of munged schuylkill nwis .csv
    destination: [str] directory where prms data file is located
    prms_predictions: [str] name of prms file'''
outputs:
    nwis_trenton_location: [str] same location as input but gap filled discharge
    nwis_schuylkill_location: [str] same location as input but gap filled discharge