### PR TITLE
update munge and it_analysis to reflect splitting at munge step

### DIFF
--- a/02_munge/munge_config.yaml
+++ b/02_munge/munge_config.yaml
@@ -108,10 +108,10 @@ fill_discharge_prms.py:
     destination: '02_munge/in/'
     fill_segments:
       trenton:
-        nwis_site: 01463500
+        nwis_site: '01463500'
         seg_id_nat: 1498
       schuylkill:
-        nwis_site: 01474500
+        nwis_site: '01474500'
         seg_id_nat: 2338
     
 

--- a/03a_it_analysis/it_analysis_data_prep_config.yaml
+++ b/03a_it_analysis/it_analysis_data_prep_config.yaml
@@ -9,7 +9,7 @@ it_analysis_data_prep.py:
         - 'wspdir'
         - 'wl_range'
         - 'wl_max'
-        - 'wl_obs_pred'
+        - 'wl_range'
         - 'wl_filtered'
         - 'conductivity'
         - 'air_pressure'
@@ -106,7 +106,7 @@ it_analysis_data_prep.py:
     #number of lags to analyze
     n_lags: 0
     #where to write the sinks and lagged sources as binary pickle files
-    out_dir: '03_it_analysis/out/'
+    out_dir: '03a_it_analysis/out/'
     #should preprocessing plots be saved
     plot: True
     

--- a/03a_it_analysis/make_heatmap_matrix_config.yaml
+++ b/03a_it_analysis/make_heatmap_matrix_config.yaml
@@ -1,7 +1,7 @@
 make_heatmap_matrix.py:
     #lagged sources from file
-    srcs_lagged_pickle: '03_it_analysis/out/srcs_proc_lagged'
+    srcs_lagged_pickle: '03a_it_analysis/out/srcs_proc_lagged'
     #sinks from file
-    snks_list_pickle: '03_it_analysis/out/snks_proc'
+    snks_list_pickle: '03a_it_analysis/out/snks_proc'
     #directory to save the correlation matrix
-    out_dir: '03_it_analysis/out/'
+    out_dir: '03a_it_analysis/out/'

--- a/03a_it_analysis/plot_heatmap_config.yaml
+++ b/03a_it_analysis/plot_heatmap_config.yaml
@@ -1,12 +1,12 @@
 plot_heatmap.py:
     #matrix to plot
-    mi_matrix: '03_it_analysis/out/mi_matrix'
-    corr_matrix: '03_it_analysis/out/corr_matrix'
+    mi_matrix: '03a_it_analysis/out/mi_matrix'
+    corr_matrix: '03a_it_analysis/out/corr_matrix'
     #mask threshold mutual information
     mask_threshold_mi: 0.01
     #mask threshold correlation
     mask_threshold_corr: 0.05
     #save location
-    save_location: '03_it_analysis/out/'
+    save_location: '03a_it_analysis/out/'
     #save? true/false
     save: True

--- a/03a_it_analysis/src/make_heatmap_matrix.py
+++ b/03a_it_analysis/src/make_heatmap_matrix.py
@@ -92,7 +92,7 @@ def create_mutual_information_matrix(srcs_lagged_pickle, snks_list_pickle ,out_d
 ###
 def main():
     # import config
-    with open("03_it_analysis/make_heatmap_matrix_config.yaml", 'r') as stream:
+    with open("03a_it_analysis/make_heatmap_matrix_config.yaml", 'r') as stream:
         config = yaml.safe_load(stream)['make_heatmap_matrix.py']
     
     #select the sources

--- a/03a_it_analysis/src/plot_heatmap.py
+++ b/03a_it_analysis/src/plot_heatmap.py
@@ -37,11 +37,11 @@ def plot_heatmap(matrix, mask_threshold, metric, date_start, date_end, save_loca
         
 def main():
     # import config from data prep step
-    with open("03_it_analysis/it_analysis_data_prep_config.yaml", 'r') as stream:
+    with open("03a_it_analysis/it_analysis_data_prep_config.yaml", 'r') as stream:
         config_data_prep = yaml.safe_load(stream)['it_analysis_data_prep.py']
     
     #import config file 
-    with open("03_it_analysis/plot_heatmap_config.yaml", 'r') as stream:
+    with open("03a_it_analysis/plot_heatmap_config.yaml", 'r') as stream:
         config = yaml.safe_load(stream)['plot_heatmap.py']
     
     date_start = config_data_prep['date_start']


### PR DESCRIPTION
This PR cleans up some some file names and make sure that the munge and it_analysis steps feed smoothly into each other after #74 . 

Specifically:
- a few changes had to be made to `it_analysis_data_prep` to read data files from both `02_munge/out/D` and `02_munge/out/daily_summaries`
- a change had to be made to correctly append the site name to the variable name within the `select_sources` function in 'it_data_analysis.py'
- references to `03_it_analysis` needed to be changed to `03a_it_analysis`