### PR TITLE
add functional performance functions snakemake

### DIFF
--- a/03a_it_analysis/snakefile_func_perf.smk
+++ b/03a_it_analysis/snakefile_func_perf.smk
@@ -5,7 +5,7 @@ sys.path.insert(0, '03a_it_analysis\\src')
 sys.path.append('methods_exploration')
 import estuary_salinity_functional_performance_func as esfp
 
-run_id = 'Run_45'
+run_id = 'Run_48'
 sources = ['discharge_01474500','discharge_01463500']
 sinks = ['saltfront_obs', 'ml_pred','coawst_pred']
 years = ['2001','2002','2003','2004','2005','2006','2007','2008','2009','2010',

--- a/03a_it_analysis/snakefile_func_perf.smk
+++ b/03a_it_analysis/snakefile_func_perf.smk
@@ -1,0 +1,42 @@
+import pickle
+import os
+import sys
+sys.path.insert(0, 'C:\\Users\\ggorski\\OneDrive - DOI\\USGS_ML\\Estuary Salinity\\github\\drb-estuary-salinity-ml\\03a_it_analysis\\src')
+import estuary_salinity_functional_performance_func as esfp
+
+run_id = 'Run_45'
+sources = ['discharge_01474500','discharge_01463500']
+sinks = ['saltfront_obs', 'ml_pred','coawst_pred']
+years = ['2001','2002','2003','2004','2005','2006','2007','2008','2009','2010',
+        '2011','2012','2013','2014','2015', '2016','2017', '2018','2019','2020'] 
+
+
+rule create_cleaned_io_file:
+    output:
+        os.path.join('03b_model/out',run_id,'ML_COAWST_Results_Input_Cleaned.csv')
+    run:
+        esfp.create_cleaned_io_file(run_id)
+
+rule calc_it_metrics_for_pairs:
+    input:
+        os.path.join('03b_model/out',run_id,'ML_COAWST_Results_Input_Cleaned.csv')
+    output:
+        os.path.join('03a_it_analysis/out',run_id+'_it_df.csv')
+    run:
+        esfp.calc_it_metrics_for_pairs(data_loc = input[0], 
+                                    sources = sources, 
+                                    sinks = sinks, 
+                                    years = years, 
+                                    write_loc = output[0])
+                                    
+rule calc_functional_performance:
+    input:
+        os.path.join('03a_it_analysis/out/',run_id+'_it_df.csv')
+    output:
+        os.path.join('03a_it_analysis/out', run_id+'_functional_performance_df.csv')
+    run:
+        esfp.calc_functional_performance(it_df_loc = input[0], 
+                                        sources = sources, 
+                                        sinks = sinks, 
+                                        years = years, 
+                                        write_loc = output[0])

--- a/03a_it_analysis/snakefile_func_perf.smk
+++ b/03a_it_analysis/snakefile_func_perf.smk
@@ -1,7 +1,7 @@
 import pickle
 import os
 import sys
-sys.path.insert(0, 'C:\\Users\\ggorski\\OneDrive - DOI\\USGS_ML\\Estuary Salinity\\github\\drb-estuary-salinity-ml\\03a_it_analysis\\src')
+sys.path.insert(0, '03a_it_analysis\\src')
 import estuary_salinity_functional_performance_func as esfp
 
 run_id = 'Run_45'

--- a/03a_it_analysis/snakefile_func_perf.smk
+++ b/03a_it_analysis/snakefile_func_perf.smk
@@ -2,6 +2,7 @@ import pickle
 import os
 import sys
 sys.path.insert(0, '03a_it_analysis\\src')
+sys.path.append('methods_exploration')
 import estuary_salinity_functional_performance_func as esfp
 
 run_id = 'Run_45'

--- a/03a_it_analysis/src/estuary_salinity_functional_performance_func.py
+++ b/03a_it_analysis/src/estuary_salinity_functional_performance_func.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Oct 18 12:54:24 2022
+
+@author: ggorski
+"""
+import it_functions
+import itertools
+import numpy as np
+import os
+import pandas as pd
+import xarray as xr
+
+
+def create_cleaned_io_file(run_id):
+    '''
+    creates a cleaned csv with aggregate results from 5 replicates and merges
+    with input data and outputs from COAWST model, saves csv to 03b_model/out
+    directory
+
+    Parameters
+    ----------
+    run_id : str
+        the run number to aggregate
+
+    Returns
+    -------
+    None.
+
+    '''
+    reps = ['00','01','02','03','04']
+    ml_sf = pd.read_csv(os.path.join('03b_model/out',run_id,reps[0],'ModelResults.csv'), parse_dates = True, index_col = 'Unnamed: 0')
+    for i,rep in enumerate(reps):
+        temp = pd.read_csv(os.path.join('03b_model/out',run_id,rep,'ModelResults.csv'), parse_dates = True, index_col = 'Unnamed: 0')
+        ml_sf['saltfront_pred_'+rep] = temp['saltfront_pred'].copy()
+
+    ml_sf_mean = ml_sf[['saltfront_pred','saltfront_pred_01','saltfront_pred_02','saltfront_pred_03','saltfront_pred_04']].mean(axis = 1)
+    ml_sf = ml_sf.merge(ml_sf_mean.rename('ml_pred'), left_index = True, right_index = True)
+
+    ml_sf = ml_sf[['saltfront_obs','ml_pred','train/val']]
+
+    # read in observations
+    inputs = xr.open_zarr(os.path.join('03b_model/out/inputs.zarr'), consolidated=False)
+    inputs_df = inputs.to_dataframe()
+    
+    #join ml and inputs
+    ml_sf_inputs = ml_sf.join(inputs_df)
+
+    ## read in COAWST model output
+    coawst_2016 = pd.read_csv('03b_model/in/COAWST_model_runs/processed/COAWST_2016_7day.csv', parse_dates = True, index_col = 'date')
+    coawst_2018 = pd.read_csv('03b_model/in/COAWST_model_runs/processed/COAWST_2018_7day.csv', parse_dates = True, index_col = 'date')
+    coawst_2019 = pd.read_csv('03b_model/in/COAWST_model_runs/processed/COAWST_2019_7day.csv', parse_dates = True, index_col = 'date')
+    coawst_3_years = pd.concat([coawst_2016, coawst_2018, coawst_2019])
+    
+    ## 
+    fp_data = ml_sf_inputs.join(coawst_3_years, how = 'outer')
+    
+    fp_data.to_csv(os.path.join('03b_model\\out',run_id,'ML_COAWST_Results_Input_Cleaned.csv'))
+
+
+def calc_it_metrics_for_pairs(data_loc, sources, sinks, years, write_loc):
+    '''
+     Generate pairs of sources and sinks from the list for each year (or range of years) listed, 
+     then calculate the transfer entropy (TE), mutual information (MI), and correlation for those pairs at
+     time lags of 0 to 10 days (hard coded now). Critical values for TE and MI are calculated as well. 
+     The raw data are preprocessed using the preprocessing functions in it_funcitons.py. 
+     The results are then converted to a dataframe and written to the file
+    Parameters
+    ----------
+    data_loc : str
+        location of cleaned data
+    sources : list
+        list of column names to use as sources
+    sinks : list
+        list of column names to use as sinks ['saltfront_obs','ml_pred','coawst_pred']
+    years : list
+        list of years to analyze, years can either be a single year ('2019') or a span ('2018:2020')
+    write_loc : str
+        location to write the results
+
+    Returns
+    -------
+    None.
+
+    '''
+    it_dict = {}
+    
+    data = pd.read_csv(data_loc, parse_dates=True, index_col = 0)    
+
+    source_sink_pairs = list(itertools.product(sources, sinks, years))
+
+    #import preprocessing functions
+    ppf = it_functions.pre_proc_func()
+    
+    for pair in source_sink_pairs:
+        
+        source = pair[0]
+        sink = pair[1]
+        year = pair[2]
+        
+        print('Calculating IT metrics for: ',source,'->',sink, year)
+        
+        #check if there is a colon which represents a range of years to 
+        #analyze, if not it will be a single year
+        if ':' in year:
+            year_range = year.split(':')
+            xy_data = data.loc[year_range[0]:year_range[1]][[source,sink]]
+        else:
+            xy_data = data.loc[year][[source,sink]]
+        
+        #if there are no (few) values in the sink variable then move on
+        if (xy_data[sink].count() < 100) | (xy_data[source].count() < 100):
+            continue
+        #different pre-processing for different variables
+        #x is source y is sink
+        #if multiple years then the remove_seasonal_signal function is used
+        if ':' in year:
+            #if discharge is the source then take the log
+            if 'discharge' in source:    
+                x = xy_data.iloc[:,0]
+                xl10 = ppf.log10(x)
+                x_rss = ppf.remove_seasonal_signal(xl10)
+                x_ss = ppf.standardize(x_rss)
+            else:
+                x = xy_data.iloc[:,0]
+                x_rss = ppf.remove_seasonal_signal(x)
+                x_ss = ppf.standardize(x_rss)   
+
+            #multiple years for salt front
+            y = xy_data.iloc[:,1]
+            y_rss = ppf.remove_seasonal_signal(y)
+            y_ss = ppf.standardize(y_rss)
+        #if we are only looking at a single year then no seasonal signal is removed
+        else:
+            #if we are preprocessing discharge then the log transform is taken and then the data are standardized
+            if 'discharge' in source:
+                x = xy_data.iloc[:,0]
+                xl10 = ppf.log10(x)
+                x_ss = ppf.standardize(xl10)
+            else:
+                x = xy_data.iloc[:,0]
+                x_ss = ppf.standardize(x)
+           #no seasonal signal removed because only one year of anlaysis
+            y = xy_data.iloc[:,1]
+            y_ss = ppf.standardize(y) 
+
+            
+        
+        #calculate it metrics for observations
+        n_lags = 10
+        nbins = 11
+        M = np.stack((x_ss,y_ss), axis = 1)
+        Mswap = np.stack((y_ss, x_ss), axis = 1)
+
+        x_bounds = it_functions.find_bounds(M[:,0], 0.1, 99.9)
+        y_bounds = it_functions.find_bounds(M[:,1], 0.1, 99.9)
+        M_x_bound = np.delete(M, np.where((M[:,0] < x_bounds[0]*1.1) | (M[:,0] > x_bounds[1]*1.1)), axis = 0)
+        M_xy_bound = np.delete(M_x_bound, np.where((M_x_bound[:,1] < y_bounds[0]*1.1) | (M_x_bound[:,1] > y_bounds[1]*1.1)), axis = 0)
+
+        it_dict[pair] = it_functions.calc_it_metrics(M_xy_bound, Mswap, n_lags, nbins, calc_swap = False, alpha = 0.01, ncores = 8)
+    
+    #convert it_dict to data frame
+    it_df = pd.DataFrame()
+    for key in it_dict.keys():
+        if 'TEswap' in it_dict[key].keys():
+            if len(it_dict[key]['TEswap']) == 0:
+                del it_dict[key]['TEswap']
+                del it_dict[key]['TEcritswap']
+        temp_df = pd.DataFrame(data = it_dict[key])
+        temp_df['source'] = key[0]
+        temp_df['sink'] = key[1]
+        temp_df['year'] = key[2]
+        temp_df['lag'] = range(0,len(temp_df))
+        #get TE from t = 3
+        it_df = pd.concat([it_df,temp_df])
+
+    it_df.to_csv(write_loc)
+
+def calc_functional_performance(it_df_loc, sources, sinks, years, write_loc):
+    '''
+    Using the calculations of transfer entropy at various time lags, this function
+    calculates the functional performance for each source/sink/year pairing by 
+    subtracting the modeled transfer entropy from the observed. The resulting
+    dataframe of functional performances are written to the file as a csv.
+
+    Parameters
+    ----------
+    it_df_loc : str
+        location of the it_df dataframe created by calc_it_metrics_for_pairs
+    sources : list
+        list of column names to use as sources. Must be the same as found in the it_df dataframe
+    sinks : list
+        list of column names to use as sinks ['saltfront_obs','ml_pred','coawst_pred']. Must be the same as found in the it_df dataframe
+    years : list
+        list of years to analyze, years can either be a single year ('2019') or a span ('2018:2020'). Must be the same as found in the it_df dataframe
+    write_loc : str
+        location to write the resulting csv to file
+    Returns
+    -------
+    None.
+
+    '''
+    it_df = pd.read_csv(it_df_loc)
+    
+    it_df_obs = it_df[it_df.sink == 'saltfront_obs'].groupby(['lag','year','source'])['TE'].mean()
+    it_df_ml_pred = it_df[it_df.sink == 'ml_pred'].groupby(['lag','year','source'])['TE'].mean()
+
+    ml_func_perf_df = it_df_ml_pred.subtract(it_df_obs).to_frame().reset_index()
+    ml_func_perf_df['model'] = 'ml'
+    
+    if 'coawst_pred' in it_df.sink.unique():
+        it_df_coawst_pred = it_df[it_df.sink == 'coawst_pred'].groupby(['lag','year','source'])['TE'].mean()
+        coawst_func_perf_df = it_df_coawst_pred.subtract(it_df_obs).to_frame().reset_index()
+        coawst_func_perf_df['model'] = 'coawst'
+        
+        func_perf_df = pd.concat([ml_func_perf_df, coawst_func_perf_df])
+    else:
+        func_perf_df = ml_func_perf_df
+    
+    func_perf_df = func_perf_df.rename(columns={'TE':'Func_Perf'})
+    
+    func_perf_df.to_csv(write_loc)
+    
+    
+
+

--- a/03a_it_analysis/src/estuary_salinity_functional_performance_func.py
+++ b/03a_it_analysis/src/estuary_salinity_functional_performance_func.py
@@ -12,6 +12,29 @@ import pandas as pd
 import xarray as xr
 
 
+def find_reps(run_id):
+    '''
+    find the list of directories that house the replicates
+    Parameters
+    ----------
+    run_id : str
+        the run number to aggregate
+
+    Returns
+    -------
+    reps : list
+        list of replicates
+
+    '''
+    reps = list()
+    rootdir = os.path.join('03b_model/out',run_id)
+    for file in os.listdir(rootdir):
+        d = os.path.join(rootdir, file)
+        #replicates have to be in a directory with a two character name(e.g., "02")
+        if os.path.isdir(d) and len(file) == 2:
+            reps.append(file)
+    return reps
+
 def create_cleaned_io_file(run_id):
     '''
     creates a cleaned csv with aggregate results from 5 replicates and merges
@@ -28,7 +51,8 @@ def create_cleaned_io_file(run_id):
     None.
 
     '''
-    reps = ['00','01','02','03','04']
+    #reps = ['00','01','02','03','04']
+    reps = find_reps(run_id)
     ml_sf = pd.read_csv(os.path.join('03b_model/out',run_id,reps[0],'ModelResults.csv'), parse_dates = True, index_col = 'Unnamed: 0')
     for i,rep in enumerate(reps):
         temp = pd.read_csv(os.path.join('03b_model/out',run_id,rep,'ModelResults.csv'), parse_dates = True, index_col = 'Unnamed: 0')
@@ -62,7 +86,7 @@ def calc_it_metrics_for_pairs(data_loc, sources, sinks, years, write_loc):
     '''
      Generate pairs of sources and sinks from the list for each year (or range of years) listed, 
      then calculate the transfer entropy (TE), mutual information (MI), and correlation for those pairs at
-     time lags of 0 to 10 days (hard coded now). Critical values for TE and MI are calculated as well. 
+     time lags of 0 to 9 days (hard coded now). Critical values for TE and MI are calculated as well. 
      The raw data are preprocessed using the preprocessing functions in it_funcitons.py. 
      The results are then converted to a dataframe and written to the file
     Parameters
@@ -138,6 +162,7 @@ def calc_it_metrics_for_pairs(data_loc, sources, sinks, years, write_loc):
                 xl10 = ppf.log10(x)
                 x_ss = ppf.standardize(xl10)
             else:
+                #no seasonal signal removed because only one year of anlaysis
                 x = xy_data.iloc[:,0]
                 x_ss = ppf.standardize(x)
            #no seasonal signal removed because only one year of anlaysis

--- a/03a_it_analysis/src/estuary_salinity_functional_performance_func.py
+++ b/03a_it_analysis/src/estuary_salinity_functional_performance_func.py
@@ -51,14 +51,13 @@ def create_cleaned_io_file(run_id):
     None.
 
     '''
-    #reps = ['00','01','02','03','04']
     reps = find_reps(run_id)
     ml_sf = pd.read_csv(os.path.join('03b_model/out',run_id,reps[0],'ModelResults.csv'), parse_dates = True, index_col = 'Unnamed: 0')
     for i,rep in enumerate(reps):
         temp = pd.read_csv(os.path.join('03b_model/out',run_id,rep,'ModelResults.csv'), parse_dates = True, index_col = 'Unnamed: 0')
         ml_sf['saltfront_pred_'+rep] = temp['saltfront_pred'].copy()
 
-    ml_sf_mean = ml_sf[['saltfront_pred','saltfront_pred_01','saltfront_pred_02','saltfront_pred_03','saltfront_pred_04']].mean(axis = 1)
+    ml_sf_mean = ml_sf.filter(regex='saltfront_pred_').mean(axis = 1)
     ml_sf = ml_sf.merge(ml_sf_mean.rename('ml_pred'), left_index = True, right_index = True)
 
     ml_sf = ml_sf[['saltfront_obs','ml_pred','train/val']]


### PR DESCRIPTION
This is a cleaned up version of the functional performance calculations with a snakemake wrapper to run the functions. The three functions are:

- `create_cleaned_io_data` -- generate cleaned up data for functional performance calcs
- `calc_it_metrics_for_pairs` -- calculate TE, MI, correlation for pairs of sources and sinks during time periods specified
- `calc_functional_performance` -- using the TE calculated from `calc_it_metrics_for_pairs` calculate difference between observed and modeled and save to file