### PR TITLE
Add lagged input

### DIFF
--- a/03b_model/model_config.yaml
+++ b/03b_model/model_config.yaml
@@ -1,10 +1,8 @@
 out_dir: '03b_model/out'
 
-<<<<<<< HEAD
+
 run_id: 'Run_51'  
-=======
-run_id: 'Run_48'  
->>>>>>> 614972a (add lagged input option)
+
 
 inputs: ['discharge_01463500', 
                 #'specific_conductance_01463500',
@@ -31,7 +29,7 @@ antecedant_variables: ['discharge']
 
 #include lagged input only for discharge
 include_lagged_input: True
-lag: 7
+lag: [7,8]
 
 
 #set the seed for reproducibility for a single model run

--- a/03b_model/model_config.yaml
+++ b/03b_model/model_config.yaml
@@ -1,8 +1,6 @@
 out_dir: '03b_model/out'
 
-
-run_id: 'Run_51'  
-
+run_id: 'Run_52'  
 
 inputs: ['discharge_01463500', 
                 #'specific_conductance_01463500',

--- a/03b_model/model_config.yaml
+++ b/03b_model/model_config.yaml
@@ -1,6 +1,10 @@
 out_dir: '03b_model/out'
 
+<<<<<<< HEAD
 run_id: 'Run_51'  
+=======
+run_id: 'Run_48'  
+>>>>>>> 614972a (add lagged input option)
 
 inputs: ['discharge_01463500', 
                 #'specific_conductance_01463500',
@@ -24,6 +28,11 @@ replicates: 10
 include_antecedant_data: False
 window_size: [60]
 antecedant_variables: ['discharge']
+
+#include lagged input only for discharge
+include_lagged_input: True
+lag: 7
+
 
 #set the seed for reproducibility for a single model run
 #if replicates are run using the run_replicates function

--- a/03b_model/model_config.yaml
+++ b/03b_model/model_config.yaml
@@ -27,6 +27,7 @@ antecedant_variables: ['discharge']
 
 #include lagged input only for discharge
 include_lagged_input: True
+#list of the lags for Delaware and Schuylkill
 lag: [7,8]
 
 

--- a/03b_model/src/run_model.py
+++ b/03b_model/src/run_model.py
@@ -158,8 +158,11 @@ def select_inputs_targets(inputs, target, train_start_date, test_end_date, out_d
     
     #include lagged inputs, fill NAs with median values
     if config['include_lagged_input']:
-        inputs_df['discharge_01463500'+'_lag'+str(config['lag'])] = inputs_df['discharge_01463500'].shift(config['lag']).fillna(10107.86)
-        inputs_df['discharge_01474500'+'_lag'+str(config['lag'])] = inputs_df['discharge_01474500'].shift(config['lag']).fillna(2316.667)
+        inputs_df['discharge_01463500'+'_lag'+str(config['lag'][0])] = inputs_df['discharge_01463500'].shift(config['lag'][0]).fillna(10107.86)
+        inputs_df['discharge_01474500'+'_lag'+str(config['lag'][1])] = inputs_df['discharge_01474500'].shift(config['lag'][1]).fillna(2316.667)
+        #inputs_df = inputs_df.drop(columns = 'discharge_01463500')
+        #inputs_df = inputs_df.drop(columns = 'discharge_01474500')
+
     
     #read in the salt front record
     target_df = pd.read_csv(os.path.join('03a_it_analysis', 'in', 'saltfront_updated.csv'), parse_dates = True, index_col = 'datetime')
@@ -384,6 +387,10 @@ def write_model_params(out_dir, run_id, inputs, n_epochs,
         for var in config['antecedant_variables']: 
             for w in config['window_size']: 
                 inputs_log.append(var+'_'+str(w).rjust(3,'0')+'_mean')
+    
+    if config['include_lagged_input']:
+        inputs_log.append('discharge_01463500'+'_lag'+str(config['lag'][0]))
+        inputs_log.append('discharge_01474500'+'_lag'+str(config['lag'][1]))
     
     f = open(os.path.join(dir,"model_param_output.txt"),"w+")
     f.write("Date: %s\r\n" % date.today().strftime("%b-%d-%Y"))

--- a/03b_model/src/run_model.py
+++ b/03b_model/src/run_model.py
@@ -156,7 +156,7 @@ def select_inputs_targets(inputs, target, train_start_date, test_end_date, out_d
         
         inputs_df = inputs_df.dropna()
     
-    #include lagged inputs, fill NAs with median values
+    #include lagged inputs, drop the first `lag` number of days from the record
     if config['include_lagged_input']:
         inputs_df['discharge_01463500'+'_lag'+str(config['lag'][0])] = inputs_df['discharge_01463500'].shift(config['lag'][0])
         inputs_df['discharge_01474500'+'_lag'+str(config['lag'][1])] = inputs_df['discharge_01474500'].shift(config['lag'][1])

--- a/03b_model/src/run_model.py
+++ b/03b_model/src/run_model.py
@@ -158,8 +158,11 @@ def select_inputs_targets(inputs, target, train_start_date, test_end_date, out_d
     
     #include lagged inputs, fill NAs with median values
     if config['include_lagged_input']:
-        inputs_df['discharge_01463500'+'_lag'+str(config['lag'][0])] = inputs_df['discharge_01463500'].shift(config['lag'][0]).fillna(10107.86)
-        inputs_df['discharge_01474500'+'_lag'+str(config['lag'][1])] = inputs_df['discharge_01474500'].shift(config['lag'][1]).fillna(2316.667)
+        inputs_df['discharge_01463500'+'_lag'+str(config['lag'][0])] = inputs_df['discharge_01463500'].shift(config['lag'][0])
+        inputs_df['discharge_01474500'+'_lag'+str(config['lag'][1])] = inputs_df['discharge_01474500'].shift(config['lag'][1])
+        
+        inputs_df.drop(inputs_df.index[0:max(config['lag'])], inplace = True)
+        
         #inputs_df = inputs_df.drop(columns = 'discharge_01463500')
         #inputs_df = inputs_df.drop(columns = 'discharge_01474500')
 
@@ -183,7 +186,11 @@ def select_inputs_targets(inputs, target, train_start_date, test_end_date, out_d
 
     mask = target_df_c[target] < 54
     target_df_c.loc[mask,target] = np.nan
-
+    
+    #if lagged inputs are included then remove the nans
+    if config['include_lagged_input']:
+        target_df_c.drop(target_df_c.index[0:max(config['lag'])], inplace = True)
+        
     inputs_xarray = inputs_df.to_xarray()
     target_xarray = target_df_c.to_xarray()
     

--- a/03b_model/src/run_model.py
+++ b/03b_model/src/run_model.py
@@ -156,6 +156,10 @@ def select_inputs_targets(inputs, target, train_start_date, test_end_date, out_d
         
         inputs_df = inputs_df.dropna()
     
+    #include lagged inputs, fill NAs with median values
+    if config['include_lagged_input']:
+        inputs_df['discharge_01463500'+'_lag'+str(config['lag'])] = inputs_df['discharge_01463500'].shift(config['lag']).fillna(10107.86)
+        inputs_df['discharge_01474500'+'_lag'+str(config['lag'])] = inputs_df['discharge_01474500'].shift(config['lag']).fillna(2316.667)
     
     #read in the salt front record
     target_df = pd.read_csv(os.path.join('03a_it_analysis', 'in', 'saltfront_updated.csv'), parse_dates = True, index_col = 'datetime')

--- a/Snakefile_b_ml_model_baseline
+++ b/Snakefile_b_ml_model_baseline
@@ -44,9 +44,9 @@ rule all_b_ml_model_baseline:
 rule prepare_inputs_targets:
     input:
         "03b_model/model_config.yaml",
-        #expand("02_munge/out/D/usgs_nwis_{usgs_nwis_site}.csv", usgs_nwis_site = usgs_nwis_sites),
-        #expand("02_munge/out/daily_summaries/noaa_nos_{noaa_nos_site}.csv", noaa_nos_site = noaa_nos_sites),
-        #expand("02_munge/out/D/noaa_nerrs_{noaa_nerr_site}.csv", noaa_nerr_site = noaa_nerr_site)
+        expand("02_munge/out/D/usgs_nwis_{usgs_nwis_site}.csv", usgs_nwis_site = usgs_nwis_sites),
+        expand("02_munge/out/daily_summaries/noaa_nos_{noaa_nos_site}.csv", noaa_nos_site = noaa_nos_sites),
+        expand("02_munge/out/D/noaa_nerrs_{noaa_nerr_site}.csv", noaa_nerr_site = noaa_nerr_site)
     output:
         directory("03b_model/out/inputs.zarr"),
         directory("03b_model/out/target.zarr"),

--- a/Snakefile_b_ml_model_baseline
+++ b/Snakefile_b_ml_model_baseline
@@ -135,7 +135,7 @@ rule make_plot_save_predictions:
 rule run_replicates:
     input:
         "03b_model/model_config.yaml", 
-        os.path.join(config['out_dir'],'prepped_model_io_data')
+        #os.path.join(config['out_dir'],'prepped_model_io_data')
     output:
         expand(os.path.join(config['out_dir'], config['run_id'], '{rep}/model_param_output.txt'), rep = replicates),
         expand(os.path.join(config['out_dir'], config['run_id'], '{rep}/losses.png'), rep = replicates),


### PR DESCRIPTION
This is a change to add lagged inputs as predictors to the model. The inputs that are lagged are discharge in the Delaware (`discharge_01463500`) and in the Schuylkill (`discharge_01474500`), they are lagged by 7 and 8 days, respectively. Those numbers are hard coded for now. The lagged variables are added in addition to the unlagged discharge.

The other change is to update the hyperparameters including, the number of replicates from 5 to 10.